### PR TITLE
fix(repl): prefer debug format syntax in the repl

### DIFF
--- a/examples/to2txt-repl/wasm/src/lib.rs
+++ b/examples/to2txt-repl/wasm/src/lib.rs
@@ -1,8 +1,6 @@
-use to2txt::Todo;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn parse(input: &str) -> String {
-    let todos: Vec<Todo> = to2txt::from_str(input).collect();
-    serde_json::to_string_pretty(&todos).unwrap_or_default()
+    format!("{:#?}", &to2txt::from_str(input).collect::<Vec<_>>())
 }


### PR DESCRIPTION
In my opinion, this approach is more meaningful to Rust devs who are considering using the library.

<img width="768" alt="Screenshot 2025-06-04 alle 10 33 47 PM" src="https://github.com/user-attachments/assets/07b92f96-b599-4f5e-9a9b-bfdb49c1381c" />
