### PR TITLE
fix(to2txt): support leading whitespace in task descriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "to2txt"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/examples/to2txt-repl/wasm/Cargo.toml
+++ b/examples/to2txt-repl/wasm/Cargo.toml
@@ -12,6 +12,5 @@ serde_json = "1"
 wasm-bindgen = "0.2"
 
 [dependencies.to2txt]
-# path = "../../.."
-version = "1.0.0-beta.1"
+path = "../../.."
 features = ["serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,4 @@ mod parser;
 mod todotxt;
 
 pub use parser::from_str;
-pub use todotxt::{Located, Priority, Span, Tag, Todo};
+pub use todotxt::{Description, Located, Priority, Span, Tag, Todo};

--- a/src/todotxt.rs
+++ b/src/todotxt.rs
@@ -7,6 +7,12 @@ use serde::{Serialize, Serializer};
 
 use crate::parser::{self, Input};
 
+pub(crate) type Headers = (
+    Option<Span>,
+    Option<Priority>,
+    Option<(Located<NaiveDate>, Option<Located<NaiveDate>>)>,
+);
+
 #[cfg_attr(
     feature = "serde",
     derive(Serialize),
@@ -125,6 +131,14 @@ impl Todo<'_> {
     pub fn tags(&self) -> impl Iterator<Item = Tag> {
         let description = &self.description;
         parser::tags(description.span, description.data.as_ref())
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.description.data.trim().is_empty()
+            && self.checkmark.is_none()
+            && self.priority.is_none()
+            && self.completed.is_none()
+            && self.started.is_none()
     }
 }
 


### PR DESCRIPTION
Closes #34

---

Trims leading and trailing whitespace in task descriptions while maintaining the correct span start and end with regards to the original parser input.

This prevents a number of edge cases that prevent a todo from being parsed from a line of text while supporting multiple spaces between the individual components of a todo. Keeping the spans in tact means that features like pretty printing and syntax highlighting can be implemented despite the description having a trimmed start and end.

This functionality, in my opinion–is the intersection of flexibility and correctness that we want short writing a tokenizer that outputs an AST that is passed in to a second parsing step. I want to be mindful of the fact that our competition is whatever regular expression support is available in the host language of your next todo.txt app. Limiting the scope and keeping things simple should give us a competitive edge.