### PR TITLE
refactor(to2txt): additional parser code cleanup + fix named tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod parser;
 mod todotxt;
 
-pub use parser::from_str;
-pub use todotxt::{Description, Located, Priority, Span, Tag, Todo};
+pub use parser::{from_str, Located, Span};
+pub use todotxt::{Description, Priority, Tag, Todo};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,7 +7,6 @@ use nom::sequence::{delimited, preceded, separated_pair, terminated};
 use nom::{IResult, Parser};
 use nom_locate::position;
 use std::borrow::Cow;
-use std::fmt::Debug;
 use std::str::FromStr;
 
 #[cfg(feature = "serde")]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,40 +2,44 @@ use chrono::NaiveDate;
 use nom::branch::alt;
 use nom::bytes::complete::{is_not, tag, take, take_while1};
 use nom::character::complete::{line_ending, one_of, space0, space1};
-use nom::combinator::{iterator, map, map_opt, map_parser, map_res, opt, verify};
+use nom::combinator::{eof, iterator, map, map_opt, map_parser, map_res, opt, peek};
 use nom::sequence::{delimited, preceded, separated_pair, terminated};
 use nom::{IResult, Parser};
 use nom_locate::position;
 use std::borrow::Cow;
 use std::str::FromStr;
 
-use crate::todotxt::{Description, Located, Priority, Span, Tag, Todo};
+#[cfg(feature = "serde")]
+use serde::Serialize;
 
-pub type Input<'a> = nom_locate::LocatedSpan<&'a str>;
+use crate::todotxt::{Description, Priority, Tag, Todo};
 
 type Error<'a> = nom::error::Error<Input<'a>>;
-type Headers = (
-    Option<Span>,
-    Option<Priority>,
-    Option<(Located<NaiveDate>, Option<Located<NaiveDate>>)>,
-);
+type Input<'a> = nom_locate::LocatedSpan<&'a str>;
+
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Located<T> {
+    pub(crate) data: T,
+    pub(crate) span: Span,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct Span {
+    start: usize,
+    end: usize,
+}
 
 /// Parse a todo list from the provided `&str`.
 ///
-pub fn from_str(value: &str) -> impl Iterator<Item = Todo<'_>> {
-    iterator(value.into(), delimited(eol, todo(), eol)).filter(|todo| {
-        !todo.description.text().trim().is_empty()
-            || !matches!(
-                todo,
-                Todo {
-                    x: None,
-                    priority: None,
-                    date_completed: None,
-                    date_started: None,
-                    ..
-                }
-            )
-    })
+pub fn from_str(input: &str) -> impl Iterator<Item = Todo<'_>> {
+    let parse1 = alt((
+        map(map_parser(preceded(space0, is_not("\r\n")), todo()), Some),
+        map(preceded(space0, peek(one_of("\r\n"))), |_| None),
+    ));
+
+    iterator(input.into(), delimited(eol, parse1, eol)).flatten()
 }
 
 pub fn tags<'a>(description: &'a Description) -> impl Iterator<Item = Tag<'a>> {
@@ -73,73 +77,55 @@ pub fn tags<'a>(description: &'a Description) -> impl Iterator<Item = Tag<'a>> {
 
 /// Returns a parser that parses a single task on a todo list.
 ///
-pub fn todo<'a>() -> impl Parser<Input<'a>, Output = Todo<'a>, Error = Error<'a>> {
-    alt((
-        map(
-            (position, preceded(space0, headers()), description()),
-            |(pos, headers, description)| {
-                let (x, priority, dates) = headers;
-                let (date_completed, date_started) = match dates {
-                    Some((first, Some(second))) => (Some(first), Some(second)),
-                    Some((first, None)) => (None, Some(first)),
-                    None => (None, None),
-                };
-                Todo {
-                    line: pos.location_line(),
-                    x,
-                    priority,
-                    date_completed,
-                    date_started,
-                    description,
-                }
-            },
-        ),
-        map((position, description()), |(pos, description)| Todo {
-            line: pos.location_line(),
-            x: None,
-            priority: None,
-            date_completed: None,
-            date_started: None,
-            description,
-        }),
-    ))
-}
-
-fn description<'a>() -> impl Parser<Input<'a>, Output = Description<'a>, Error = Error<'a>> {
-    map(is_not("\r\n"), |output: Input<'a>| {
-        let text = output.fragment().trim_end();
-        let offset = text.len() - text.trim_start().len();
-        let span_start = output.get_utf8_column() - 1 + offset;
-
-        Description(Located {
-            data: Cow::Borrowed(&text[offset..]),
-            span: Span::new(span_start, span_start + text.len()),
-        })
-    })
-}
-
-fn headers<'a>() -> impl Parser<Input<'a>, Output = Headers, Error = Error<'a>> {
-    verify(
+fn todo<'a>() -> impl Parser<Input<'a>, Output = Todo<'a>, Error = Error<'a>> {
+    let uppercase = one_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    map(
         (
+            map(position, |pos: Input<'a>| pos.location_line()),
             opt(map(terminated(tag("x"), space1), |pos| {
                 Span::locate(&pos, 1)
             })),
             opt(map(
-                (
-                    position,
-                    terminated(
-                        delimited(tag("("), one_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), tag(")")),
-                        space1,
-                    ),
-                ),
+                terminated((position, delimited(tag("("), uppercase, tag(")"))), space1),
                 |(pos, data)| {
                     let span = Span::locate(&pos, 3);
                     Priority(Located { data, span })
                 },
             )),
             opt((ymd(), opt(ymd()))),
+            alt((
+                map(preceded(space0, is_not("\r\n")), |output: Input<'a>| {
+                    let data = output.into_fragment().trim_end();
+
+                    Description(Located {
+                        data: Cow::Borrowed(data),
+                        span: Span::locate(&output, data.len()),
+                    })
+                }),
+                map(eof, |pos| {
+                    Description(Located {
+                        data: Cow::Borrowed(""),
+                        span: Span::locate(&pos, 0),
+                    })
+                }),
+            )),
         ),
-        |output| !matches!(output, (None, None, None)),
+        |(line, x, priority, dates, description)| {
+            let (date_completed, date_started) = match dates {
+                Some((first, Some(second))) => (Some(first), Some(second)),
+                Some((first, None)) => (None, Some(first)),
+                None => (None, None),
+            };
+
+            Todo {
+                line,
+                x,
+                priority,
+                date_completed,
+                date_started,
+                description,
+            }
+        },
     )
 }
 
@@ -180,10 +166,58 @@ fn ymd<'a>() -> impl Parser<Input<'a>, Output = Located<NaiveDate>, Error = Erro
     })
 }
 
+impl<T> Located<T> {
+    /// A reference to value of the associated item.
+    ///
+    pub fn data(&self) -> &T {
+        &self.data
+    }
+
+    /// The location of the associated item.
+    ///
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+}
+
+impl Span {
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    pub fn end(&self) -> usize {
+        self.end
+    }
+}
+
+impl Span {
+    #[cfg(test)]
+    pub(crate) fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+
+    fn locate(input: &Input, len: usize) -> Self {
+        let start = input.get_utf8_column() - 1;
+        let end = start + len;
+        Self { start, end }
+    }
+
+    fn locate_from(input: &Input, len: usize, offset: usize) -> Self {
+        let span = Self::locate(input, len);
+
+        Self {
+            start: span.start + offset,
+            end: span.end + offset,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::todotxt::{Description, Located, Span};
     use std::borrow::Cow;
+
+    use super::{Located, Span};
+    use crate::todotxt::Description;
 
     #[test]
     fn test_parse_tags() {

--- a/src/todotxt.rs
+++ b/src/todotxt.rs
@@ -87,7 +87,7 @@ impl Todo<'_> {
     /// Returns an iterator over the tags in the todo's description.
     ///
     pub fn tags(&self) -> impl Iterator<Item = Tag<'_>> {
-        parser::tags(&self.description)
+        parser::parse_tags(&self.description)
     }
 
     /// True if the todo starts with a lowercase "x" or has a `completed` date.

--- a/src/todotxt.rs
+++ b/src/todotxt.rs
@@ -8,7 +8,7 @@ use serde::ser::SerializeStruct;
 #[cfg(feature = "serde")]
 use serde::{Serialize, Serializer};
 
-use crate::parser::{self, Input};
+use crate::parser::{self, Located, Span};
 
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Clone, Debug, PartialEq)]
@@ -28,20 +28,6 @@ pub enum Tag<'a> {
     Context(Located<&'a str>),
     Project(Located<&'a str>),
     Named(Located<(&'a str, &'a str)>),
-}
-
-#[cfg_attr(feature = "serde", derive(Serialize))]
-#[derive(Clone, Debug, PartialEq)]
-pub struct Located<T> {
-    pub(crate) data: T,
-    pub(crate) span: Span,
-}
-
-#[cfg_attr(feature = "serde", derive(Serialize))]
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
-pub struct Span {
-    start: usize,
-    end: usize,
 }
 
 /// A task from a todo list.
@@ -77,20 +63,6 @@ impl Description<'_> {
     }
 }
 
-impl<T> Located<T> {
-    /// A reference to value of the associated item.
-    ///
-    pub fn data(&self) -> &T {
-        &self.data
-    }
-
-    /// The location of the associated item.
-    ///
-    pub fn span(&self) -> &Span {
-        &self.span
-    }
-}
-
 impl Priority {
     /// Returns the `char` that is used for prioritization and ordering.
     ///
@@ -108,37 +80,6 @@ impl PartialOrd for Priority {
         self.rank()
             .partial_cmp(&other.rank())
             .map(Ordering::reverse)
-    }
-}
-
-impl Span {
-    pub fn start(&self) -> usize {
-        self.start
-    }
-
-    pub fn end(&self) -> usize {
-        self.end
-    }
-
-    pub(crate) fn locate_from(input: &Input, len: usize, offset: usize) -> Self {
-        let Self { start, end } = Self::locate(input, len);
-
-        Self {
-            start: start + offset,
-            end: end + offset,
-        }
-    }
-}
-
-impl Span {
-    pub(crate) fn new(start: usize, end: usize) -> Self {
-        Self { start, end }
-    }
-
-    pub(crate) fn locate(input: &Input, len: usize) -> Self {
-        let start = input.get_utf8_column() - 1;
-        let end = start + len;
-        Self { start, end }
     }
 }
 


### PR DESCRIPTION
Refactors the parser code to make better use of parser combinators. Also fixes a bug where named tags are not parsed (i.e `due:2025-06-08`)