### PR TITLE
refactor(to2txt): sensible token types + cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = ["dep:serde", "chrono/serde"]
 [dependencies]
 chrono = "0.4"
 nom = "8"
-nom_locate = "5.0.0"
+nom_locate = "5"
 
 [dependencies.serde]
 version = "1"

--- a/examples/to2txt-repl/src/app/page.tsx
+++ b/examples/to2txt-repl/src/app/page.tsx
@@ -31,7 +31,11 @@ export default function Home(): JSX.Element {
         </section>
         <section className={clsx(styles.pane, "overflow-y-auto")}>
           <Output
-            className={clsx("px-4.5 py-4 text-sm", anonymousPro.className)}
+            className={clsx(
+              "px-4.5 py-4",
+              styles.output,
+              anonymousPro.className,
+            )}
             value={tasks}
           />
         </section>

--- a/examples/to2txt-repl/src/styles/page.module.css
+++ b/examples/to2txt-repl/src/styles/page.module.css
@@ -11,13 +11,18 @@
 }
 
 .header {
-  @apply absolute top-0 right-4.5 left-4.5 h-16 text-2xl select-none;
+  @apply absolute top-0 right-4.5 left-4.5 h-16 text-3xl select-none;
   background: var(--color-midnight);
   line-height: 4rem;
 }
 
 .input {
-  @apply min-h-full w-full px-4.5 pt-16 pb-4 text-sm text-gray-200 leading-relaxed;
+  @apply min-h-full w-full px-4.5 pt-16 pb-4 text-gray-200 leading-relaxed;
+  font-size: 0.9375rem;
+}
+
+.output {
+  font-size: 0.9375rem;
 }
 
 .pane {

--- a/examples/to2txt-repl/wasm/src/lib.rs
+++ b/examples/to2txt-repl/wasm/src/lib.rs
@@ -1,6 +1,16 @@
+use std::fmt::{self, Debug, Formatter};
+
 use wasm_bindgen::prelude::*;
+
+struct Tasks<'a>(&'a str);
+
+impl Debug for Tasks<'_> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_list().entries(to2txt::from_str(self.0)).finish()
+    }
+}
 
 #[wasm_bindgen]
 pub fn parse(input: &str) -> String {
-    format!("{:#?}", &to2txt::from_str(input).collect::<Vec<_>>())
+    format!("{:#?}", Tasks(input))
 }

--- a/examples/to2txt-repl/wasm/src/lib.rs
+++ b/examples/to2txt-repl/wasm/src/lib.rs
@@ -1,16 +1,20 @@
-use std::fmt::{self, Debug, Formatter};
+mod s_expr;
 
+use std::fmt::Write;
 use wasm_bindgen::prelude::*;
 
-struct Tasks<'a>(&'a str);
-
-impl Debug for Tasks<'_> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.debug_list().entries(to2txt::from_str(self.0)).finish()
-    }
-}
+use s_expr::WriteSExpr;
 
 #[wasm_bindgen]
-pub fn parse(input: &str) -> String {
-    format!("{:#?}", Tasks(input))
+pub fn parse(input: &str) -> Result<String, String> {
+    let mut output = String::new();
+
+    for task in to2txt::from_str(input) {
+        let s_expr = WriteSExpr::new(&task);
+        if let Err(e) = writeln!(&mut output, "{}", s_expr) {
+            return Err(e.to_string());
+        }
+    }
+
+    Ok(output)
 }

--- a/examples/to2txt-repl/wasm/src/s_expr.rs
+++ b/examples/to2txt-repl/wasm/src/s_expr.rs
@@ -1,0 +1,96 @@
+use std::fmt::{self, Display, Formatter};
+use to2txt::{Tag, Task};
+
+pub struct WriteSExpr<'a> {
+    task: &'a Task<'a>,
+}
+
+impl<'a> WriteSExpr<'a> {
+    pub fn new(task: &'a Task) -> Self {
+        Self { task }
+    }
+}
+
+impl Display for WriteSExpr<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "(line {}", self.task.line())?;
+        writeln!(f, "{:>2}(task", " ")?;
+
+        if let Some(x) = &self.task.x {
+            writeln!(f, "{:>4}(x {:?})", " ", x.offset())?;
+        }
+
+        if let Some(priority) = &self.task.priority {
+            writeln!(
+                f,
+                "{:>4}(priority {:?} {})",
+                " ",
+                priority.offset(),
+                priority.value(),
+            )?;
+        }
+
+        if let Some(finished_on) = &self.task.finished_on {
+            writeln!(
+                f,
+                "{:>4}(finished_on {:?} {})",
+                " ",
+                finished_on.offset(),
+                finished_on.value(),
+            )?;
+        }
+
+        if let Some(started_on) = &self.task.started_on {
+            writeln!(
+                f,
+                "{:>4}(started_on {:?} {})",
+                " ",
+                started_on.offset(),
+                started_on.value(),
+            )?;
+        }
+
+        let description = &self.task.description;
+        let n_tags = self.task.tags().count();
+
+        write!(
+            f,
+            "{:>4}(description {:?} {:?}{}",
+            " ",
+            description.offset(),
+            description.fragment(),
+            if n_tags > 0 { "" } else { ")))" },
+        )?;
+
+        for (index, tag) in self.task.tags().enumerate() {
+            if index == 0 {
+                writeln!(f, "")?;
+            }
+
+            match tag.value() {
+                Tag::Context(context) => {
+                    let offset = context.offset();
+                    let value = context.value();
+
+                    write!(f, "{:>6}(context {:?} {:?})", " ", offset, value)?;
+                }
+                Tag::Project(project) => {
+                    let offset = project.offset();
+                    let value = project.value();
+
+                    write!(f, "{:>6}(project {:?} {:?})", " ", offset, value)?;
+                }
+                Tag::Named(key, value) => {
+                    let offset = (key.start(), value.end());
+                    let value = (key.fragment(), value.fragment());
+
+                    write!(f, "{:>6}(named {:?} {:?})", " ", offset, value)?;
+                }
+            };
+
+            writeln!(f, "{}", if index == n_tags - 1 { ")))" } else { "" })?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod parser;
 mod task;
 
-pub use parser::{Token, from_str};
+pub use parser::{Span, Token, from_str};
 pub use task::{Priority, Tag, Task};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod parser;
 mod task;
 
-pub use parser::{Span, Token, from_str};
+pub use parser::{Token, from_str};
 pub use task::{Priority, Tag, Task};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -162,19 +162,13 @@ fn ymd(input: Input) -> IResult<Input, (i32, u32, u32)> {
     parser.parse(input)
 }
 
-impl Span {
+impl<T> Token<T> {
     pub fn start(&self) -> usize {
-        self.0
+        self.span().0
     }
 
     pub fn end(&self) -> usize {
-        self.1
-    }
-}
-
-impl<T> Token<T> {
-    pub fn span(&self) -> &Span {
-        &self.span
+        self.span().1
     }
 }
 
@@ -220,6 +214,10 @@ impl<T> Token<T> {
         let span = Span(start, start + len);
 
         Self { value, span }
+    }
+
+    fn span(&self) -> &Span {
+        &self.span
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -50,7 +50,7 @@ pub fn task1(input: Text) -> IResult<Text, Task> {
             (tag("("), one_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), tag(")")),
             |(open, uppercase, _)| Token {
                 // Safety: The one_of combinator ensures uppercase is 65..=90.
-                value: unsafe { mem::transmute::<u32, Priority>(uppercase as _) },
+                value: unsafe { mem::transmute::<u8, Priority>(uppercase as _) },
                 span: Span::new(3, &open),
             },
         ))),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -41,7 +41,7 @@ pub fn from_str(input: &str) -> impl Iterator<Item = Task<'_>> {
 
 /// Parse a single task from the first line of `input`.
 ///
-pub fn task_opt(input: &str) -> Option<Task> {
+pub fn task_opt(input: &str) -> Option<Task<'_>> {
     match preceded(space0, task1).parse(input.into()) {
         Ok((_, task)) if task_is_empty(&task) => None,
         Ok((_, task)) => Some(task),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -223,13 +223,17 @@ impl Token<Cow<'_, str>> {
         self.value.into_owned()
     }
 
-    pub(crate) fn as_input(&self, line: u32) -> Text {
+    pub(crate) fn as_input(&self, line: u32) -> Text<'_> {
         let fragment = self.as_str();
-        let offset = self.span().start();
+        let span = self.span();
 
         unsafe {
             // Safety:
-            Text::new_from_raw_offset(offset, line, fragment, ())
+            //
+            // Any span produced from the following type will be >=
+            // span.start() and <= span.end().
+            //
+            Text::new_from_raw_offset(span.start(), line, fragment, ())
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,21 +2,21 @@ use chrono::NaiveDate;
 use nom::branch::alt;
 use nom::bytes::complete::{is_not, tag, take, take_till1};
 use nom::character::complete::{multispace0, one_of, space0, space1};
-use nom::combinator::{iterator, map, map_opt, map_parser, map_res, opt, rest};
+use nom::combinator::{iterator, map, map_opt, map_parser, map_res, opt, recognize, rest};
 use nom::sequence::{delimited, preceded, separated_pair, terminated};
-use nom::{IResult, Input as ImplInput, Offset, Parser};
+use nom::{IResult, Input, Offset, Parser};
 use nom_locate::LocatedSpan;
 use std::mem;
 use std::str::FromStr;
 
 use crate::task::{Priority, Tag, Task};
 
-type Error<'a> = nom::error::Error<LocatedSpan<&'a str>>;
-type Input<'a> = LocatedSpan<&'a str>;
+type Error<'a> = nom::error::Error<Span<'a>>;
+type Span<'a, T = ()> = LocatedSpan<&'a str, T>;
 
 #[derive(Clone, Debug)]
 pub struct Token<'a, T = ()> {
-    span: LocatedSpan<&'a str, T>,
+    span: Span<'a, T>,
 }
 
 /// Parse a todo list from the provided `&str`.
@@ -25,7 +25,31 @@ pub fn from_str(input: &str) -> impl Iterator<Item = Task<'_>> {
     iterator(input.into(), delimited(multispace0, task1, multispace0))
 }
 
-pub fn task1(input: Input) -> IResult<Input, Task> {
+pub fn tags<'a>(input: &Token<'a>) -> impl Iterator<Item = Token<'a, Tag<'a>>> {
+    let tag1 = map_parser(
+        preceded(space0, word),
+        opt(alt((
+            item(map(recognize((tag("@"), word)), |context| {
+                let value = &context.fragment()[1..];
+                Tag::Context(Token::new(context.map_extra(|_| value)))
+            })),
+            item(map(recognize((tag("+"), word)), |project| {
+                let value = &project.fragment()[1..];
+                Tag::Project(Token::new(project.map_extra(|_| value)))
+            })),
+            item(map(
+                separated_pair(is_not(" :"), tag(":"), word),
+                |(key, value)| Tag::Named(Token::new(key), Token::new(value)),
+            )),
+        ))),
+    );
+
+    iterator(input.to_span(), tag1).flatten()
+}
+
+/// Parse an individual task from the input.
+///
+pub fn task1(input: Span) -> IResult<Span, Task> {
     let parts = (
         opt(xspace1(map(tag("x"), Token::new))),
         opt(xspace1(item(map(
@@ -55,84 +79,63 @@ pub fn task1(input: Input) -> IResult<Input, Task> {
         },
     );
 
-    parser.parse(input)
+    parser.parse_complete(input)
 }
 
-pub fn tags<'a>(input: &Token<'a>) -> impl Iterator<Item = Token<'a, Tag<'a>>> {
-    let tag1 = map_parser(
-        preceded(space0, word),
-        opt(alt((
-            item(map(preceded(tag("@"), word), |context| {
-                Tag::Context(Token::new(context))
-            })),
-            item(map(preceded(tag("+"), word), |project| {
-                Tag::Project(Token::new(project))
-            })),
-            item(map(
-                separated_pair(is_not(" :"), tag(":"), word),
-                |(key, value)| Tag::Named(Token::new(key), Token::new(value)),
-            )),
-        ))),
+fn date(input: Span) -> IResult<Span, NaiveDate> {
+    let triple = (
+        terminated(parse_to(take(4usize)), tag("-")),
+        terminated(parse_to(take(2usize)), tag("-")),
+        parse_to(take(2usize)),
     );
 
-    iterator(input.span, tag1).flatten()
+    map_opt(triple, |(y, m, d)| NaiveDate::from_ymd_opt(y, m, d)).parse_complete(input)
 }
 
-fn date(input: Input) -> IResult<Input, NaiveDate> {
-    let mut parser = map_opt(
-        (
-            terminated(parse_to(take(4usize)), tag("-")),
-            terminated(parse_to(take(2usize)), tag("-")),
-            parse_to(take(2usize)),
-        ),
-        |(y, m, d)| NaiveDate::from_ymd_opt(y, m, d),
-    );
-
-    parser.parse(input)
-}
-
-fn item<'a, P>(mut parser: P) -> impl FnMut(Input<'a>) -> IResult<Input<'a>, Token<'a, P::Output>>
+fn item<'a, P>(
+    mut parser: P,
+) -> impl Parser<Span<'a>, Output = Token<'a, P::Output>, Error = Error<'a>>
 where
-    P: Parser<Input<'a>, Error = Error<'a>>,
+    P: Parser<Span<'a>, Error = Error<'a>>,
 {
     move |input| {
-        let (rest, value) = parser.parse(input)?;
+        let (rest, value) = parser.parse_complete(input)?;
         let span = input.take(input.offset(&rest)).map_extra(|_| value);
 
         Ok((rest, Token::new(span)))
     }
 }
 
-fn not_line_ending(input: Input) -> IResult<Input, Input> {
-    let mut parser = map(is_not("\n"), |output: Input| {
-        if output.ends_with('\r') {
-            output.take(output.len() - 1)
-        } else {
-            output
-        }
-    });
+fn not_line_ending(input: Span) -> IResult<Span, Span> {
+    let (mut rest, line) = is_not("\r\n").parse_complete(input)?;
 
-    parser.parse(input)
+    if rest.starts_with("\r\n") {
+        rest = rest.take_from(2);
+    } else if rest.starts_with("\n") || rest.starts_with("\r") {
+        rest = rest.take_from(1);
+    }
+
+    Ok((rest, line))
 }
 
-fn parse_to<'a, R, P>(parser: P) -> impl Parser<Input<'a>, Output = R, Error = Error<'a>>
+fn parse_to<'a, R, P>(parser: P) -> impl Parser<Span<'a>, Output = R, Error = Error<'a>>
 where
     R: FromStr,
-    P: Parser<Input<'a>, Output = Input<'a>, Error = Error<'a>>,
+    P: Parser<Span<'a>, Output = Span<'a>, Error = Error<'a>>,
 {
     map_res(parser, |output| output.fragment().parse())
 }
 
-fn word(input: Input) -> IResult<Input, Input> {
-    take_till1(char::is_whitespace).parse(input)
+fn word(input: Span) -> IResult<Span, Span> {
+    take_till1(char::is_whitespace).parse_complete(input)
 }
 
 /// Apply the provided parser to the input until one or more space or tab
 /// character is found.
 ///
-fn xspace1<'a, P>(parser: P) -> impl Parser<Input<'a>, Output = P::Output, Error = P::Error>
+fn xspace1<'a, P>(parser: P) -> impl Parser<Span<'a>, Output = P::Output, Error = P::Error>
 where
-    P: Parser<Input<'a>>,
+    P: Parser<Span<'a>>,
 {
     terminated(parser, space1)
 }
@@ -160,6 +163,15 @@ impl<T> Token<'_, T> {
         self.span.get_utf8_column()
     }
 
+    /// The start and end byte index of self in the parser input.
+    ///
+    pub fn offset(&self) -> (usize, usize) {
+        let span = &self.span;
+        let start = span.location_offset();
+
+        (start, start + span.len())
+    }
+
     /// The index of the first byte of self in the parser input.
     ///
     pub fn start(&self) -> usize {
@@ -176,60 +188,20 @@ impl<T> Token<'_, T> {
 
 impl<'a, T> Token<'a, T> {
     #[inline]
-    pub(crate) fn new(span: LocatedSpan<&'a str, T>) -> Self {
+    fn new(span: Span<'a, T>) -> Self {
         Self { span }
+    }
+}
+
+impl<'a, T: Copy> Token<'a, T> {
+    #[inline]
+    pub(crate) fn to_span(&self) -> Span<'a, T> {
+        self.span
     }
 }
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn test_span_range() {
-        const INPUT: &str = "
-            feed tomato plants
-            x (Z) 2025-06-15 2025-06-01 write tests for +to2txt
-            x (A) 2025-06-10 2025-06-01 deploy repl example to vercel +to2txt
-        ";
-
-        let mut tasks = super::from_str(INPUT);
-
-        let first = tasks.next().unwrap();
-        let second = tasks.next().unwrap();
-        let third = tasks.next().unwrap();
-
-        assert!(
-            tasks.next().is_none(),
-            "expected todo.txt to only have 3 tasks"
-        );
-
-        {
-            let description = &first.description;
-
-            assert_eq!(
-                INPUT.get(description.start()..description.end()),
-                Some("feed tomato plants"),
-            );
-        }
-
-        {
-            let description = &second.description;
-
-            assert_eq!(
-                INPUT.get(description.start()..description.end()),
-                Some("write tests for +to2txt"),
-            );
-        }
-
-        {
-            let description = &third.description;
-
-            assert_eq!(
-                INPUT.get(description.start()..description.end()),
-                Some("deploy repl example to vercel +to2txt"),
-            );
-        }
-    }
-
     #[test]
     fn test_from_str() {
         assert_eq!(super::from_str("feed tomato plants").count(), 1);
@@ -237,6 +209,30 @@ mod tests {
             super::from_str("feed tomato plants\n  water palm\nfeed monstera").count(),
             3
         );
+    }
+
+    #[test]
+    fn test_not_line_ending() {
+        const INPUTS: [&str; 2] = [
+            "read until new line\r\nline 2",
+            "read until new line\nline 2",
+        ];
+
+        for input in INPUTS.into_iter() {
+            let (line2, line1) = super::not_line_ending(input.into()).unwrap();
+
+            assert_eq!(
+                line1.into_fragment(),
+                "read until new line",
+                "the input is read until the terminating sequence is reached",
+            );
+
+            assert_eq!(
+                line2.into_fragment(),
+                "line 2",
+                "the terminating sequence is removed from the output",
+            );
+        }
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -163,18 +163,16 @@ fn ymd(input: Input) -> IResult<Input, (i32, u32, u32)> {
 }
 
 impl<T> Token<T> {
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
     pub fn start(&self) -> usize {
         self.span().0
     }
 
     pub fn end(&self) -> usize {
         self.span().1
-    }
-}
-
-impl<T: Copy> Token<T> {
-    pub fn value(&self) -> &T {
-        &self.value
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -211,9 +211,11 @@ impl<T> Token<T> {
 
     fn new(len: usize, from: &Input, value: T) -> Self {
         let start = from.get_utf8_column() - 1;
-        let span = Span(start, start + len);
 
-        Self { value, span }
+        Self {
+            value,
+            span: Span(start, start + len),
+        }
     }
 
     fn span(&self) -> &Span {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -184,6 +184,7 @@ impl Span {
 
     /// The length in bytes of the token.
     ///
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.len
     }
@@ -308,9 +309,9 @@ mod tests {
 
     #[test]
     fn test_from_str() {
-        assert_eq!(super::from_str("feed tomato plants".into()).count(), 1);
+        assert_eq!(super::from_str("feed tomato plants").count(), 1);
         assert_eq!(
-            super::from_str("feed tomato plants\n  water palm\nfeed monstera".into()).count(),
+            super::from_str("feed tomato plants\n  water palm\nfeed monstera").count(),
             3
         );
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -59,13 +59,13 @@ pub fn task(input: Input) -> IResult<Input, Option<Task>> {
             Some(Task {
                 line: from.location_line(),
                 x: x.map(|value| Token::new(1, &from, value)),
-                priority: priority.map(|(f, ascii, _)| {
+                priority: priority.map(|(f, uppercase, _)| {
                     Token::new(
                         3,
                         &f,
                         // Safety:
                         // The one_of combinator ensures uppercase is 65..=90.
-                        unsafe { mem::transmute::<u32, Priority>(ascii as _) },
+                        unsafe { mem::transmute::<u32, Priority>(uppercase as _) },
                     )
                 }),
                 completed_on: completed_on.and_then(date_from_ymd),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -66,7 +66,7 @@ pub fn task1(input: Text) -> IResult<Text, Task> {
     let mut parser = map(
         map_parser(not_line_ending, parts),
         |(start, x, priority, dates, description)| {
-            let (started_on, completed_on) = match dates {
+            let (started_on, finished_on) = match dates {
                 Some((d1, d2 @ Some(_))) => (d2, Some(d1)),
                 Some((d1, None)) => (Some(d1), None),
                 None => (None, None),
@@ -77,7 +77,7 @@ pub fn task1(input: Text) -> IResult<Text, Task> {
                 x,
                 line,
                 priority,
-                finished_on: completed_on,
+                finished_on,
                 started_on,
                 description,
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -54,7 +54,8 @@ pub fn task1(input: Text) -> IResult<Text, Task> {
                 span: Span::new(3, &open),
             },
         ))),
-        opt((xspace1(date), opt(xspace1(date)))),
+        opt(xspace1(date)),
+        opt(xspace1(date)),
         map(rest, |output: Text| {
             let value = Cow::Borrowed(output.fragment().trim_ascii_end());
             let span = Span::new(value.len(), &output);
@@ -65,13 +66,12 @@ pub fn task1(input: Text) -> IResult<Text, Task> {
 
     let mut parser = map(
         map_parser(not_line_ending, parts),
-        |(start, x, priority, dates, description)| {
-            let (started_on, finished_on) = match dates {
-                Some((d1, d2 @ Some(_))) => (d2, Some(d1)),
-                Some((d1, None)) => (Some(d1), None),
-                None => (None, None),
-            };
+        |(start, x, priority, mut finished_on, mut started_on, description)| {
             let line = start.location_line();
+
+            if started_on.is_none() {
+                mem::swap(&mut finished_on, &mut started_on);
+            }
 
             Task {
                 x,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -52,7 +52,7 @@ pub fn task(input: Input) -> IResult<Input, Option<Task>> {
         ),
     );
 
-    parser.parse(input).map(|(rest, parts)| match &parts {
+    parser.parse(input).map(|(rest, parts)| match parts {
         (_, None, None, None, None, description) if description.is_empty() => (rest, None),
         (from, x, priority, completed_on, started_on, description) => (
             rest,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -136,7 +136,7 @@ pub(crate) fn task_as_input<'a>(task: &'a Task) -> Input<'a> {
         //
         // The tags of a task are parsed lazily to avoid a dynamic, per-task
         // allocation. In order to facilitate this, we have to create a new
-        // LocatedSpan, identical to the one used to create the task's
+        // LocatedSpan identical to the one used to create the task's
         // description token.
         //
         // We know that the line number of the provided task and the span of

--- a/src/task.rs
+++ b/src/task.rs
@@ -62,7 +62,7 @@ impl Task<'_> {
         let description = &self.description;
         let input = description.as_str();
 
-        parser::tags(description.span().start(), input)
+        parser::tags(description.start(), input)
     }
 
     /// True when `x` or `completed_on` is present.
@@ -92,7 +92,7 @@ impl Debug for Task<'_> {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
                 let Self(description) = *self;
                 let input = description.as_str();
-                let tags = parser::tags(description.span().start(), input);
+                let tags = parser::tags(description.start(), input);
 
                 f.debug_list().entries(tags).finish()
             }
@@ -114,29 +114,23 @@ impl Debug for Task<'_> {
 
 impl Display for Task<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let x = &self.x;
-        let priority = &self.priority;
-        let completed_on = &self.completed_on;
-        let started_on = &self.started_on;
-        let description = &self.description;
-
-        if x.is_some() {
+        if self.x.is_some() {
             write!(f, "x ")?;
         }
 
-        if let Some(token) = priority.as_ref() {
+        if let Some(token) = self.priority.as_ref() {
             write!(f, "({}) ", token.value())?;
         }
 
-        if let Some(token) = completed_on.as_ref() {
+        if let Some(token) = self.completed_on.as_ref() {
             write!(f, "{} ", token.value())?;
         }
 
-        if let Some(token) = started_on.as_ref() {
+        if let Some(token) = self.started_on.as_ref() {
             write!(f, "{} ", token.value())?;
         }
 
-        f.write_str(description.as_str())
+        f.write_str(self.description.as_str())
     }
 }
 
@@ -160,7 +154,7 @@ impl Serialize for Task<'_> {
             fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
                 let Self(description) = *self;
                 let input = description.as_str();
-                let tags = parser::tags(description.span().start(), input);
+                let tags = parser::tags(description.start(), input);
 
                 serializer.collect_seq(tags)
             }

--- a/src/task.rs
+++ b/src/task.rs
@@ -36,14 +36,14 @@ pub enum Tag<'a> {
 /// A task from a todo list.
 ///
 #[derive(Clone)]
-#[non_exhaustive]
 pub struct Task<'a> {
-    pub line: u32,
     pub x: Option<Token<bool>>,
     pub priority: Option<Token<Priority>>,
     pub finished_on: Option<Token<NaiveDate>>,
     pub started_on: Option<Token<NaiveDate>>,
     pub description: Token<Cow<'a, str>>,
+
+    pub(crate) line: u32,
 }
 
 impl Display for Priority {

--- a/src/task.rs
+++ b/src/task.rs
@@ -156,16 +156,18 @@ impl Task<'_> {
     /// Returns true if the task contains only whitespace
     ///
     pub(crate) fn is_empty(&self) -> bool {
-        match self {
-            Self {
-                x: None,
-                priority: None,
-                finished_on: None,
-                started_on: None,
-                description,
-                ..
-            } => description.as_str().trim_ascii_end().is_empty(),
-            _ => false,
+        if let Self {
+            x: None,
+            priority: None,
+            finished_on: None,
+            started_on: None,
+            description,
+            ..
+        } = self
+        {
+            description.as_str().trim_ascii_end().is_empty()
+        } else {
+            false
         }
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -98,19 +98,21 @@ impl Task<'_> {
         let fragment = description.as_str();
         let offset = description.span().start();
 
-        // Safety:
-        //
-        // The tags of a task are parsed lazily to avoid a dynamic, per-task
-        // allocation. In order to facilitate this, we have to create a new
-        // LocatedSpan identical to the one used to create the task's
-        // description token.
-        //
-        // We know that the line number of the provided task and the span of
-        // it's description are valid. Therefore, we know that a LocatedSpan
-        // created from these values will be structurally identical to the
-        // source of the description token.
-        //
-        let input = unsafe { LocatedSpan::new_from_raw_offset(offset, self.line, fragment, ()) };
+        let input = unsafe {
+            // Safety:
+            //
+            // The tags of a task are parsed lazily to avoid a dynamic, per-task
+            // allocation. In order to facilitate this, we have to create a new
+            // LocatedSpan identical to the one used to create the task's
+            // description token.
+            //
+            // We know that the line number of the provided task and the span of
+            // it's description are valid. Therefore, we know that a LocatedSpan
+            // created from these values will be structurally identical to the
+            // source of the description token.
+            //
+            LocatedSpan::new_from_raw_offset(offset, self.line, fragment, ())
+        };
 
         parser::tags(input)
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -64,20 +64,20 @@ impl<'a> Task<'a> {
 
     /// True when the task starts with a "x".
     ///
-    pub fn x(&self) -> Option<&Token> {
-        self.x.as_ref()
+    pub fn x(&self) -> bool {
+        self.x.is_some()
     }
 
-    pub fn priority(&self) -> Option<&Token<Priority>> {
-        self.priority.as_ref()
+    pub fn priority(&self) -> Option<&Priority> {
+        Some(self.priority.as_ref()?.value())
     }
 
-    pub fn finished_on(&self) -> Option<&Token<NaiveDate>> {
-        self.finished_on.as_ref()
+    pub fn finished_on(&self) -> Option<&NaiveDate> {
+        Some(self.finished_on.as_ref()?.value())
     }
 
-    pub fn started_on(&self) -> Option<&Token<NaiveDate>> {
-        self.started_on.as_ref()
+    pub fn started_on(&self) -> Option<&NaiveDate> {
+        Some(self.started_on.as_ref()?.value())
     }
 
     /// A str to the task's description text.

--- a/src/task.rs
+++ b/src/task.rs
@@ -60,9 +60,7 @@ impl Task<'_> {
     ///
     pub fn tags(&self) -> impl Iterator<Item = Tag<'_>> {
         let description = &self.description;
-        let input = description.as_str();
-
-        parser::tags(description.start(), input)
+        parser::tags(description.start(), description.as_str())
     }
 
     /// True when `x` or `completed_on` is present.
@@ -91,8 +89,7 @@ impl Debug for Task<'_> {
         impl Debug for DebugTags<'_> {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
                 let Self(description) = *self;
-                let input = description.as_str();
-                let tags = parser::tags(description.start(), input);
+                let tags = parser::tags(description.start(), description.as_str());
 
                 f.debug_list().entries(tags).finish()
             }
@@ -118,15 +115,15 @@ impl Display for Task<'_> {
             write!(f, "x ")?;
         }
 
-        if let Some(token) = self.priority.as_ref() {
+        if let Some(token) = &self.priority {
             write!(f, "({}) ", token.value())?;
         }
 
-        if let Some(token) = self.completed_on.as_ref() {
+        if let Some(token) = &self.completed_on {
             write!(f, "{} ", token.value())?;
         }
 
-        if let Some(token) = self.started_on.as_ref() {
+        if let Some(token) = &self.started_on {
             write!(f, "{} ", token.value())?;
         }
 
@@ -153,8 +150,7 @@ impl Serialize for Task<'_> {
         impl Serialize for SerializeTags<'_> {
             fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
                 let Self(description) = *self;
-                let input = description.as_str();
-                let tags = parser::tags(description.start(), input);
+                let tags = parser::tags(description.start(), description.as_str());
 
                 serializer.collect_seq(tags)
             }

--- a/src/task.rs
+++ b/src/task.rs
@@ -2,8 +2,6 @@ use chrono::NaiveDate;
 use nom::Parser;
 use nom::character::complete::space0;
 use nom::sequence::preceded;
-use nom_locate::LocatedSpan;
-use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::{self, Debug, Display, Formatter};
 
@@ -21,34 +19,33 @@ pub enum Priority {
     N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
 }
 
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize),
-    serde(tag = "type", content = "data", rename_all = "lowercase")
-)]
+// #[cfg_attr(
+//     feature = "serde",
+//     derive(Serialize),
+//     serde(tag = "type", content = "data", rename_all = "lowercase")
+// )]
 #[derive(Clone, Debug)]
 pub enum Tag<'a> {
-    Context(&'a str),
-    Project(&'a str),
-    Named(&'a str, &'a str),
+    Context(Token<'a>),
+    Project(Token<'a>),
+    Named(Token<'a>, Token<'a>),
 }
 
 /// A task from a todo list.
 ///
-#[derive(Clone)]
+#[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Task<'a> {
-    pub x: Option<Token<bool>>,
-    pub priority: Option<Token<Priority>>,
-    pub finished_on: Option<Token<NaiveDate>>,
-    pub started_on: Option<Token<NaiveDate>>,
-    pub description: Token<Cow<'a, str>>,
-
-    pub(crate) line: u32,
+    pub x: Option<Token<'a>>,
+    pub priority: Option<Token<'a, Priority>>,
+    pub finished_on: Option<Token<'a, NaiveDate>>,
+    pub started_on: Option<Token<'a, NaiveDate>>,
+    pub description: Token<'a>,
 }
 
 impl Display for Priority {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "({})", &((*self as u8) as char))
+        Display::fmt(&((*self as u8) as char), f)
     }
 }
 
@@ -60,61 +57,39 @@ impl PartialOrd for Priority {
     }
 }
 
-impl Task<'_> {
-    /// The line number of the task.
-    ///
+impl<'a> Task<'a> {
     pub fn line(&self) -> u32 {
-        self.line
+        self.description.line()
     }
 
     /// True when the task starts with a "x".
     ///
-    pub fn x(&self) -> bool {
-        self.x.is_some()
+    pub fn x(&self) -> Option<&Token> {
+        self.x.as_ref()
     }
 
-    pub fn priority(&self) -> Option<&Priority> {
-        Some(self.priority.as_ref()?.value())
+    pub fn priority(&self) -> Option<&Token<Priority>> {
+        self.priority.as_ref()
     }
 
-    pub fn finished_on(&self) -> Option<&NaiveDate> {
-        Some(self.finished_on.as_ref()?.value())
+    pub fn finished_on(&self) -> Option<&Token<NaiveDate>> {
+        self.finished_on.as_ref()
     }
 
-    pub fn started_on(&self) -> Option<&NaiveDate> {
-        Some(self.started_on.as_ref()?.value())
+    pub fn started_on(&self) -> Option<&Token<NaiveDate>> {
+        self.started_on.as_ref()
     }
 
     /// A str to the task's description text.
     ///
     pub fn description(&self) -> &str {
-        self.description.as_str()
+        self.description.fragment()
     }
 
     /// An iterator over the tags in the todo's description.
     ///
-    pub fn tags(&self) -> impl Iterator<Item = Token<Tag<'_>>> {
-        let description = &self.description;
-        let fragment = description.as_str();
-        let offset = description.span().start();
-
-        let input = unsafe {
-            // Safety:
-            //
-            // The tags of a task are parsed lazily to avoid a dynamic, per-task
-            // allocation. In order to facilitate this, we have to create a new
-            // LocatedSpan identical to the one used to create the task's
-            // description token.
-            //
-            // We know that the line number of the provided task and the span of
-            // it's description are valid. Therefore, we know that a LocatedSpan
-            // created from these values will be structurally identical to the
-            // source of the description token.
-            //
-            LocatedSpan::new_from_raw_offset(offset, self.line, fragment, ())
-        };
-
-        parser::tags(input)
+    pub fn tags(&self) -> impl Iterator<Item = Token<'a, Tag<'a>>> {
+        parser::tags(&self.description)
     }
 
     /// True when `x` is some or `finished_on` is some.
@@ -126,19 +101,6 @@ impl Task<'_> {
         )
     }
 
-    /// Returns a clone of self with the description allocated on the heap.
-    ///
-    pub fn into_owned(self) -> Task<'static> {
-        Task {
-            description: self.description.map(|value| {
-                Cow::Owned(value.into_owned()) // Allocation
-            }),
-            ..self
-        }
-    }
-}
-
-impl<'a> Task<'a> {
     /// Parse an individual task from the first line of `input`.
     ///
     /// If `input` is empty or contains only whitespace, `None` is returned.
@@ -165,51 +127,33 @@ impl Task<'_> {
             ..
         } = self
         {
-            description.as_str().trim_ascii_end().is_empty()
+            description.fragment().trim_ascii_end().is_empty()
         } else {
             false
         }
     }
 }
 
-impl Debug for Task<'_> {
-    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        struct DebugTags<'a>(&'a Task<'a>);
-
-        impl Debug for DebugTags<'_> {
-            fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-                f.debug_list().entries(self.0.tags()).finish()
-            }
-        }
-
-        fmt.debug_struct("Todo")
-            .field("line", &self.line)
-            .field("x", &self.x)
-            .field("priority", &self.priority)
-            .field("finished_on", &self.finished_on)
-            .field("started_on", &self.started_on)
-            .field("description", &self.description)
-            .field("tags", &DebugTags(self))
-            .finish()
-    }
-}
-
 impl Display for Task<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        if self.x() {
-            write!(f, "x ")?;
+        if let Some(x) = &self.x {
+            f.write_str(x.fragment())?;
+            f.write_str(" ")?;
         }
 
-        if let Some(priority) = self.priority() {
-            write!(f, "{} ", priority)?;
+        if let Some(priority) = &self.priority {
+            f.write_str(priority.fragment())?;
+            f.write_str(" ")?;
         }
 
-        if let Some(finished_on) = self.finished_on() {
-            write!(f, "{} ", finished_on)?;
+        if let Some(finished_on) = &self.finished_on {
+            f.write_str(finished_on.fragment())?;
+            f.write_str(" ")?;
         }
 
-        if let Some(started_on) = self.started_on() {
-            write!(f, "{} ", started_on)?;
+        if let Some(started_on) = &self.started_on {
+            f.write_str(started_on.fragment())?;
+            f.write_str(" ")?;
         }
 
         f.write_str(self.description())
@@ -222,7 +166,7 @@ impl Serialize for Task<'_> {
         use serde::ser::SerializeStruct;
 
         struct Description<'a>(&'a Task<'a>);
-        struct Tags<'a>(&'a Task<'a>);
+        // struct Tags<'a>(&'a Task<'a>);
 
         impl Serialize for Description<'_> {
             fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -230,24 +174,24 @@ impl Serialize for Task<'_> {
                 let mut state = serializer.serialize_struct("Description", 2)?;
 
                 state.serialize_field("text", task.description())?;
-                state.serialize_field("tags", &Tags(task))?;
+                // state.serialize_field("tags", &Tags(task))?;
 
                 state.end()
             }
         }
 
-        impl Serialize for Tags<'_> {
-            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-                serializer.collect_seq(self.0.tags())
-            }
-        }
+        // impl Serialize for Tags<'_> {
+        //     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        //         serializer.collect_seq(self.0.tags())
+        //     }
+        // }
 
         let mut state = serializer.serialize_struct("Task", 5)?;
 
-        state.serialize_field("is_done", &self.is_done())?;
-        state.serialize_field("priority", &self.priority())?;
-        state.serialize_field("finished_on", &self.finished_on())?;
-        state.serialize_field("started_on", &self.started_on())?;
+        // state.serialize_field("is_done", &self.is_done())?;
+        // state.serialize_field("priority", &self.priority())?;
+        // state.serialize_field("finished_on", &self.finished_on())?;
+        // state.serialize_field("started_on", &self.started_on())?;
         state.serialize_field("description", &Description(self))?;
 
         state.end()

--- a/src/task.rs
+++ b/src/task.rs
@@ -92,7 +92,7 @@ impl Task<'_> {
         parser::tags(self.description.as_input(self.line))
     }
 
-    /// True when `x` is some or `completed_on` is some.
+    /// True when `x` is some or `finished_on` is some.
     ///
     pub fn is_done(&self) -> bool {
         matches!(

--- a/src/task.rs
+++ b/src/task.rs
@@ -105,7 +105,9 @@ impl Task<'_> {
     ///
     pub fn into_owned(self) -> Task<'static> {
         Task {
-            description: self.description.map(|value| Cow::Owned(value.into_owned())),
+            description: self.description.map(|value| {
+                Cow::Owned(value.into_owned()) // Allocation
+            }),
             ..self
         }
     }
@@ -166,8 +168,8 @@ impl FromStr for Task<'static> {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         match parser::task1(input.into()) {
             Ok((_, task)) => Ok(task.into_owned()),
-            _ => Err("unexpected end of input".to_owned()), // Allocation
-        }
+            _ => Err("unexpected end of input".to_owned()),
+        } // Allocation
     }
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -70,15 +70,15 @@ impl Task<'_> {
     }
 
     pub fn priority(&self) -> Option<&Priority> {
-        self.priority.as_ref().map(Token::value)
+        Some(self.priority.as_ref()?.value())
     }
 
     pub fn finished_on(&self) -> Option<&NaiveDate> {
-        self.finished_on.as_ref().map(Token::value)
+        Some(self.finished_on.as_ref()?.value())
     }
 
     pub fn started_on(&self) -> Option<&NaiveDate> {
-        self.started_on.as_ref().map(Token::value)
+        Some(self.started_on.as_ref()?.value())
     }
 
     /// A str to the task's description text.
@@ -121,6 +121,24 @@ impl<'a> Task<'a> {
     ///
     pub fn from_str_opt(input: &'a str) -> Option<Task<'a>> {
         parser::task_opt(input)
+    }
+}
+
+impl Task<'_> {
+    /// Returns true if the task contains only whitespace
+    ///
+    pub(crate) fn is_empty(&self) -> bool {
+        match self {
+            Self {
+                x: None,
+                priority: None,
+                finished_on: None,
+                started_on: None,
+                description,
+                ..
+            } => description.as_str().trim_ascii_end().is_empty(),
+            _ => false,
+        }
     }
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -12,7 +12,7 @@ use crate::parser::{self, Token};
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[rustfmt::skip]
-#[repr(C)]
+#[repr(u32)]
 pub enum Priority {
     A = 65, B, C, D, E, F, G, H, I, J, K, L, M,
     N, O, P, Q, R, S, T, U, V, W, X, Y, Z,

--- a/src/task.rs
+++ b/src/task.rs
@@ -12,7 +12,7 @@ use crate::parser::{self, Token};
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[rustfmt::skip]
-#[repr(u32)]
+#[repr(u8)]
 pub enum Priority {
     A = 65, B, C, D, E, F, G, H, I, J, K, L, M,
     N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
@@ -35,8 +35,8 @@ pub enum Tag<'a> {
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct Task<'a> {
-    pub x: Option<Token<bool>>,
     pub line: u32,
+    pub x: Option<Token<bool>>,
     pub priority: Option<Token<Priority>>,
     pub finished_on: Option<Token<NaiveDate>>,
     pub started_on: Option<Token<NaiveDate>>,
@@ -51,21 +51,23 @@ impl Display for Priority {
 
 impl PartialOrd for Priority {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(u32::partial_cmp(&(*self as _), &(*other as _))?.reverse())
+        (*self as u32)
+            .partial_cmp(&(*other as _))
+            .map(Ordering::reverse)
     }
 }
 
 impl Task<'_> {
-    /// True when the task starts with a "x".
-    ///
-    pub fn x(&self) -> bool {
-        self.x.is_some()
-    }
-
     /// The line number of the task.
     ///
     pub fn line(&self) -> u32 {
         self.line
+    }
+
+    /// True when the task starts with a "x".
+    ///
+    pub fn x(&self) -> bool {
+        self.x.is_some()
     }
 
     pub fn priority(&self) -> Option<&Priority> {
@@ -129,8 +131,8 @@ impl Debug for Task<'_> {
         let description = &self.description;
 
         fmt.debug_struct("Todo")
-            .field("x", &self.x)
             .field("line", &self.line)
+            .field("x", &self.x)
             .field("priority", &self.priority)
             .field("finished_on", &self.finished_on)
             .field("started_on", &self.started_on)


### PR DESCRIPTION
This is what I expect to be public API for version 1.0 of this parser. I like following semver.

Definitely going to write docs before releasing the first version. I may make a few changes after the fact if I anything comes up during that time. The API is flexible enough to do basically anything you want beside mutate the tasks.

I don't plan on adding support for mutations. If I was to build a todo.txt web or native app, I would use this parser to continuously parse the input buffer and use that as the source of truth. I like the idea of diffs only being used for synchronization rather than migrating state or deciding what to do in the event of a conflict between the AST and the text in a todo list. If I hit a bottleneck with that approach I would probably use a virtualized list of inputs and recalculate the line offset to change from the outside. It's great when data flows in one direction, especially when editing text. This preference for immutability and composition is very much a byproduct of the elegance and simplicity of the todo.txt specification. It is often a preference of mine, but not a requirement.